### PR TITLE
docs: add environment variable reference (#3)

### DIFF
--- a/iter3/.env.example
+++ b/iter3/.env.example
@@ -1,0 +1,6 @@
+APP_SECRET_KEY=your-key-here
+DB_POOL_SIZE=5
+CACHE_TTL_SECONDS=300
+LOG_LEVEL=INFO
+
+# iteration 3

--- a/iter3/README.md
+++ b/iter3/README.md
@@ -1,0 +1,13 @@
+# dev-utils
+
+Developer utilities for config, retry, and CLI tooling.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APP_SECRET_KEY` | ✅ | — | Token signing key |
+| `DB_POOL_SIZE` | ❌ | `5` | DB connection pool size |
+| `CACHE_TTL_SECONDS` | ❌ | `300` | Cache TTL |
+
+# iteration 3


### PR DESCRIPTION
## Summary
Adds env var table to README and a `.env.example` template.

## Changes
- README.md: Environment Variables section
- .env.example: template for local dev