### PR TITLE
docs: add environment variable reference (#13)

### DIFF
--- a/iter13/.env.example
+++ b/iter13/.env.example
@@ -1,0 +1,6 @@
+APP_SECRET_KEY=your-key-here
+DB_POOL_SIZE=5
+CACHE_TTL_SECONDS=300
+LOG_LEVEL=INFO
+
+# iteration 13

--- a/iter13/README.md
+++ b/iter13/README.md
@@ -1,0 +1,13 @@
+# dev-utils
+
+Developer utilities for config, retry, and CLI tooling.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APP_SECRET_KEY` | ✅ | — | Token signing key |
+| `DB_POOL_SIZE` | ❌ | `5` | DB connection pool size |
+| `CACHE_TTL_SECONDS` | ❌ | `300` | Cache TTL |
+
+# iteration 13


### PR DESCRIPTION
## Summary
Adds env var table to README and a `.env.example` template.

## Changes
- README.md: Environment Variables section
- .env.example: template for local dev