### PR TITLE
fix: handle stale connections in DB pool (#16)

### DIFF
--- a/iter16/db/pool.py
+++ b/iter16/db/pool.py
@@ -1,0 +1,21 @@
+"""DB connection pool with health checks."""
+
+class Pool:
+    def __init__(self, factory, size=5):
+        self._factory = factory
+        self._conns = [factory() for _ in range(size)]
+
+    def get(self):
+        conn = self._conns.pop()
+        if not self._ping(conn):
+            conn = self._factory()
+        return conn
+
+    def _ping(self, conn):
+        try:
+            conn.ping()
+            return True
+        except Exception:
+            return False
+
+# iteration 16

--- a/iter16/tests/test_pool.py
+++ b/iter16/tests/test_pool.py
@@ -1,0 +1,13 @@
+from unittest.mock import MagicMock
+from db.pool import Pool
+
+def test_stale_conn_recycled():
+    bad = MagicMock()
+    bad.ping.side_effect = Exception("stale")
+    good = MagicMock()
+    pool = Pool(lambda: good, size=0)
+    pool._conns = [bad]
+    conn = pool.get()
+    assert conn is good
+
+# iteration 16


### PR DESCRIPTION
## Summary
Adds health-check ping before returning a pooled connection to avoid stale socket errors.

## Changes
- db/pool.py: `_ping()` method, recycle on failure
- tests/test_pool.py: stale connection simulation