### PR TITLE
feat: add in-memory cache with TTL (#27)

### DIFF
--- a/iter27/cache/__init__.py
+++ b/iter27/cache/__init__.py
@@ -1,0 +1,4 @@
+from cache.store import Cache
+__all__ = ["Cache"]
+
+# iteration 27

--- a/iter27/cache/store.py
+++ b/iter27/cache/store.py
@@ -1,0 +1,18 @@
+"""TTL in-memory cache."""
+import time
+
+class Cache:
+    def __init__(self, ttl=300):
+        self._ttl = ttl
+        self._data = {}
+
+    def get(self, key):
+        entry = self._data.get(key)
+        if entry and time.time() < entry["exp"]:
+            return entry["val"]
+        return None
+
+    def set(self, key, val):
+        self._data[key] = {"val": val, "exp": time.time() + self._ttl}
+
+# iteration 27

--- a/iter27/tests/test_cache.py
+++ b/iter27/tests/test_cache.py
@@ -1,0 +1,15 @@
+import time
+from cache import Cache
+
+def test_hit():
+    c = Cache(ttl=60)
+    c.set("k", "v")
+    assert c.get("k") == "v"
+
+def test_expired():
+    c = Cache(ttl=0)
+    c.set("k", "v")
+    time.sleep(0.01)
+    assert c.get("k") is None
+
+# iteration 27


### PR DESCRIPTION
## Summary
Introduces a lightweight TTL-based in-memory cache to reduce redundant API calls.

## Changes
- cache/store.py: `Cache` class with TTL eviction
- cache/__init__.py: public API
- tests/test_cache.py: expiry and hit/miss tests