### PR TITLE
feat: add /healthz endpoint (#39)

### DIFF
--- a/iter39/server/health.py
+++ b/iter39/server/health.py
@@ -1,0 +1,6 @@
+"""Health check endpoint."""
+
+def healthz(request):
+    return {"status": "ok", "uptime": "running"}
+
+# iteration 39

--- a/iter39/server/router.py
+++ b/iter39/server/router.py
@@ -1,0 +1,14 @@
+"""Route registry."""
+from server.health import healthz
+
+ROUTES = {
+    "/healthz": healthz,
+}
+
+def dispatch(path, request):
+    handler = ROUTES.get(path)
+    if not handler:
+        return {"error": "not found"}, 404
+    return handler(request), 200
+
+# iteration 39

--- a/iter39/tests/test_health.py
+++ b/iter39/tests/test_health.py
@@ -1,0 +1,8 @@
+from server.router import dispatch
+
+def test_healthz_ok():
+    body, status = dispatch("/healthz", {})
+    assert status == 200
+    assert body["status"] == "ok"
+
+# iteration 39


### PR DESCRIPTION
## Summary
Adds a `/healthz` HTTP endpoint for liveness probes in containerised deployments.

## Changes
- server/health.py: handler
- server/router.py: route registration
- tests/test_health.py: 200 response assertion