### PR TITLE
refactor: decouple modules via event bus (#40)

### DIFF
--- a/iter40/events/__init__.py
+++ b/iter40/events/__init__.py
@@ -1,0 +1,5 @@
+from events.bus import EventBus
+bus = EventBus()
+__all__ = ["bus"]
+
+# iteration 40

--- a/iter40/events/bus.py
+++ b/iter40/events/bus.py
@@ -1,0 +1,15 @@
+"""Simple synchronous event bus."""
+from collections import defaultdict
+
+class EventBus:
+    def __init__(self):
+        self._handlers = defaultdict(list)
+
+    def subscribe(self, event, fn):
+        self._handlers[event].append(fn)
+
+    def publish(self, event, payload=None):
+        for fn in self._handlers[event]:
+            fn(payload)
+
+# iteration 40

--- a/iter40/tests/test_bus.py
+++ b/iter40/tests/test_bus.py
@@ -1,0 +1,9 @@
+from events import bus
+
+def test_pubsub():
+    received = []
+    bus.subscribe("test", received.append)
+    bus.publish("test", {"x": 1})
+    assert received == [{"x": 1}]
+
+# iteration 40


### PR DESCRIPTION
## Summary
Replaces direct module imports with a lightweight publish/subscribe event bus.

## Changes
- events/bus.py: `EventBus` class
- events/__init__.py: singleton instance
- tests/test_bus.py: pub/sub tests