### PR TITLE
feat: add --dry-run flag to CLI (#44)

### DIFF
--- a/iter44/cli/flags.py
+++ b/iter44/cli/flags.py
@@ -1,0 +1,6 @@
+"""CLI flag definitions."""
+FLAGS = [
+    {"name": "--dry-run", "action": "store_true", "help": "Preview without executing"},
+]
+
+# iteration 44

--- a/iter44/cli/runner.py
+++ b/iter44/cli/runner.py
@@ -1,0 +1,9 @@
+"""CLI runner with dry-run support."""
+
+def run(args):
+    if args.get("dry_run"):
+        print("[DRY RUN] Would execute:", args)
+        return
+    print("Executing:", args)
+
+# iteration 44

--- a/iter44/tests/test_cli.py
+++ b/iter44/tests/test_cli.py
@@ -1,0 +1,7 @@
+from cli.runner import run
+
+def test_dry_run_no_exec(capsys):
+    run({"dry_run": True, "cmd": "deploy"})
+    assert "[DRY RUN]" in capsys.readouterr().out
+
+# iteration 44


### PR DESCRIPTION
## Summary
Adds `--dry-run` flag that previews actions without executing them.

## Changes
- cli/runner.py: dry-run mode
- cli/flags.py: argument definition
- tests/test_cli.py: dry-run tests